### PR TITLE
Fix training script on TensorFlow r1.0+ (ValueError: softmax_cross_entropy_with_logits)

### DIFF
--- a/mnist.py
+++ b/mnist.py
@@ -93,7 +93,7 @@ biases = {
 pred = conv_net(x, weights, biases, keep_prob)
 
 # Define loss and optimizer
-cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(pred, y))
+cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=pred, labels=y))
 optimizer = tf.train.AdamOptimizer(learning_rate=learning_rate).minimize(cost)
 
 # Evaluate model


### PR DESCRIPTION
Though this script works fine on r0.11, on r1.0 and above you hit this error (I tested on r1.0, r1.2 and r1.3):
```
# python mnist.py
Extracting MNIST_data/train-images-idx3-ubyte.gz
Extracting MNIST_data/train-labels-idx1-ubyte.gz
Extracting MNIST_data/t10k-images-idx3-ubyte.gz
Extracting MNIST_data/t10k-labels-idx1-ubyte.gz
Traceback (most recent call last):
  File "mnist.py", line 96, in <module>
    cost = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(pred, y))
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/nn_ops.py", line 1558, in softmax_cross_entropy_with_logits
    labels, logits)
  File "/usr/local/lib/python2.7/dist-packages/tensorflow/python/ops/nn_ops.py", line 1512, in _ensure_xent_args
    "named arguments (labels=..., logits=..., ...)" % name)
ValueError: Only call `softmax_cross_entropy_with_logits` with named arguments (labels=..., logits=..., ...)
```
Implemented fix as described here: https://stackoverflow.com/a/42297021/112705

TESTING

After the change, I tested on TensorFlow r0.11 and r1.3, and the script runs successfully.